### PR TITLE
Catch errors in postlink script, allowing install during cross build

### DIFF
--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -52,11 +52,11 @@ if [ -z "${DOCKER_IMAGE}" ]; then
         echo "WARNING: DOCKER_IMAGE variable not set and shyaml not installed. Trying to parse with coreutils"
         DOCKER_IMAGE=$(cat .ci_support/${CONFIG}.yaml | grep '^docker_image:$' -A 1 | tail -n 1 | cut -b 3-)
         if [ "${DOCKER_IMAGE}" = "" ]; then
-            echo "No docker_image entry found in ${CONFIG}. Falling back to condaforge/linux-anvil-comp7"
-            DOCKER_IMAGE="condaforge/linux-anvil-comp7"
+            echo "No docker_image entry found in ${CONFIG}. Falling back to quay.io/condaforge/linux-anvil-comp7"
+            DOCKER_IMAGE="quay.io/condaforge/linux-anvil-comp7"
         fi
     else
-        DOCKER_IMAGE="$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 condaforge/linux-anvil-comp7 )"
+        DOCKER_IMAGE="$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 quay.io/condaforge/linux-anvil-comp7 )"
     fi
 fi
 

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -4,12 +4,14 @@ source .scripts/logging_utils.sh
 
 set -xe
 
+MINIFORGE_HOME=${MINIFORGE_HOME:-${HOME}/miniforge3}
+
 ( startgroup "Installing a fresh version of Miniforge" ) 2> /dev/null
 
 MINIFORGE_URL="https://github.com/conda-forge/miniforge/releases/latest/download"
 MINIFORGE_FILE="Miniforge3-MacOSX-x86_64.sh"
 curl -L -O "${MINIFORGE_URL}/${MINIFORGE_FILE}"
-bash $MINIFORGE_FILE -b
+bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
 
 ( endgroup "Installing a fresh version of Miniforge" ) 2> /dev/null
 
@@ -17,7 +19,7 @@ bash $MINIFORGE_FILE -b
 
 BUILD_CMD=build
 
-source ${HOME}/miniforge3/etc/profile.d/conda.sh
+source ${MINIFORGE_HOME}/etc/profile.d/conda.sh
 conda activate base
 
 echo -e "\n\nInstalling conda-forge-ci-setup=3 and conda-build."
@@ -27,11 +29,18 @@ conda install -n base --quiet --yes "conda-forge-ci-setup=3" conda-build pip ${G
 
 echo -e "\n\nSetting up the condarc and mangling the compiler."
 setup_conda_rc ./ ./recipe ./.ci_support/${CONFIG}.yaml
-mangle_compiler ./ ./recipe .ci_support/${CONFIG}.yaml
 
-echo -e "\n\nMangling homebrew in the CI to avoid conflicts."
-/usr/bin/sudo mangle_homebrew
-/usr/bin/sudo -k
+if [[ "${CI:-}" != "" ]]; then
+  mangle_compiler ./ ./recipe .ci_support/${CONFIG}.yaml
+fi
+
+if [[ "${CI:-}" != "" ]]; then
+  echo -e "\n\nMangling homebrew in the CI to avoid conflicts."
+  /usr/bin/sudo mangle_homebrew
+  /usr/bin/sudo -k
+else
+  echo -e "\n\nNot mangling homebrew as we are not running in CI"
+fi
 
 echo -e "\n\nRunning the build setup script."
 source run_conda_forge_build_setup

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,4 +1,4 @@
-setlocal EnableDelayedExpansion
+setlocal EnableExtensions EnableDelayedExpansion
 @echo on
 
 :: set pkg-config path so that host deps can be found
@@ -35,4 +35,11 @@ ninja -v -C builddir -j %CPU_COUNT%
 if errorlevel 1 exit 1
 
 ninja -C builddir install -j %CPU_COUNT%
+if errorlevel 1 exit 1
+
+:: create directory for modules so post-link script doesn't fail
+set "MODULEDIR=%LIBRARY_LIB%\gtk-3.0\3.0.0"
+if not exist "%MODULEDIR%" md "%MODULEDIR%"
+if errorlevel 1 exit 1
+type nul > "%MODULEDIR%\.keep"
 if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - no-module-warning.patch
 
 build:
-  number: 0
+  number: 1
   # workaround for bug in LIEF (https://github.com/lief-project/LIEF/issues/239)
   # that resulted in missing symbols
   rpaths_patcher: patchelf  # [linux]

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -1,6 +1,19 @@
-"%PREFIX%\Library\bin\glib-compile-schemas.exe" "%PREFIX%\Library\share\glib-2.0\schemas"
-if errorlevel 1 exit 1
-"%PREFIX%\Library\bin\gtk-update-icon-cache.exe" -f -t "%PREFIX%\Library\share\icons\hicolor"
-if errorlevel 1 exit 1
-"%PREFIX%\Library\bin\gtk-query-immodules-3.0.exe" > "%PREFIX%\Library\lib\gtk-3.0\3.0.0\immodules.cache"
-if errorlevel 1 exit 1
+:: When cross-compiling, or installing for a different platform, the commands
+:: can't be executed. So we catch errors and print a message instead of failing.
+"%PREFIX%\Library\bin\glib-compile-schemas.exe" "%PREFIX%\Library\share\glib-2.0\schemas" 2>> "%PREFIX%\.messages.txt"
+if errorlevel 1 goto ProcessError
+"%PREFIX%\Library\bin\gtk-update-icon-cache.exe" -f -t -q "%PREFIX%\Library\share\icons\hicolor" 2>> "%PREFIX%\.messages.txt"
+if errorlevel 1 goto ProcessError
+"%PREFIX%\Library\bin\gtk-query-immodules-3.0.exe" --update-cache 2>> "%PREFIX%\.messages.txt"
+if errorlevel 1 goto ProcessError
+
+exit /b 0
+
+:ProcessError
+(
+echo ERROR: Failed to complete gtk3's post-link script.
+echo To fix this, activate the environment and run:
+echo     glib-compile-schemas "%PREFIX%\Library\share\glib-2.0\schemas"
+echo     gtk-update-icon-cache -f -t "%PREFIX%\Library\share\icons\hicolor"
+echo     gtk-query-immodules-3.0 --update-cache
+) >> "%PREFIX%\.messages.txt"

--- a/recipe/post-link.sh
+++ b/recipe/post-link.sh
@@ -1,3 +1,14 @@
-"${PREFIX}/bin/glib-compile-schemas" "${PREFIX}/share/glib-2.0/schemas"
-"${PREFIX}/bin/gtk-update-icon-cache" -f -t "${PREFIX}/share/icons/hicolor"
-"${PREFIX}/bin/gtk-query-immodules-3.0" > "${PREFIX}/lib/gtk-3.0/3.0.0/immodules.cache"
+# When cross-compiling, or installing for a different platform, the commands
+# can't be executed. So we catch errors and print a message instead of failing.
+{ # try block
+    "${PREFIX}/bin/glib-compile-schemas" "${PREFIX}/share/glib-2.0/schemas" 2>>"${PREFIX}/.messages.txt" &&
+    "${PREFIX}/bin/gtk-update-icon-cache" -f -t -q "${PREFIX}/share/icons/hicolor" 2>>"${PREFIX}/.messages.txt" &&
+    "${PREFIX}/bin/gtk-query-immodules-3.0" --update-cache 2>>"${PREFIX}/.messages.txt"
+} ||
+{ # catch block
+    echo "ERROR: Failed to complete gtk3's post-link script."
+    echo "To fix this, activate the environment and run:"
+    echo "    glib-compile-schemas \"${PREFIX}/share/glib-2.0/schemas\""
+    echo "    gtk-update-icon-cache -f -t \"${PREFIX}/share/icons/hicolor\""
+    echo "    gtk-query-immodules-3.0 --update-cache"
+} >> "${PREFIX}/.messages.txt"


### PR DESCRIPTION
Extracting this portion from #35 while we wait feedback on switching to xorg packages. This is useful on its own to partially address #16 and allow installation of `gtk3` into a host environment where the platform is different from the build platform (needed for doing `osx-arm64` builds, e.g. https://github.com/conda-forge/gnuradio-feedstock/pull/57).
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
