### PR TITLE
Fix cross script

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -5,7 +5,7 @@
 jobs:
 - job: linux
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-latest
   strategy:
     matrix:
       linux_64_:

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -86,7 +86,7 @@ jobs:
 
     - script: |
         call activate base
-        conda.exe build "recipe" -m .ci_support\%CONFIG%.yaml
+        conda.exe build "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables
       displayName: Build recipe
       env:
         PYTHONUNBUFFERED: 1

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -7,7 +7,7 @@ c_compiler_version:
 cairo:
 - '1.16'
 channel_sources:
-- conda-forge/label/rust_dev,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 freetype:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -38,8 +38,8 @@ if [[ "$CONDA_BUILD_CROSS_COMPILATION" == "1" ]]; then
 
     export CC=$CC_FOR_BUILD
     export OBJC=$OBJC_FOR_BUILD
-    export AR=($CC_FOR_BUILD -print-prog-name=ar)
-    export NM=($CC_FOR_BUILD -print-prog-name=nm)
+    export AR="$($CC_FOR_BUILD -print-prog-name=ar)"
+    export NM="$($CC_FOR_BUILD -print-prog-name=nm)"
     export LDFLAGS=${LDFLAGS//$PREFIX/$BUILD_PREFIX}
     export PKG_CONFIG_PATH=${BUILD_PREFIX}/lib/pkgconfig
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
     - quartz-fix.diff  # [osx]
 
 build:
-  number: 1
+  number: 2
   # workaround for bug in LIEF (https://github.com/lief-project/LIEF/issues/239)
   # that resulted in missing symbols
   rpaths_patcher: patchelf  # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,8 +34,7 @@ build:
 
 requirements:
   build:
-    # restrict to working meson, see https://github.com/conda-forge/gtk3-feedstock/pull/26
-    - meson 0.56.2
+    - meson
     - ninja
     - gobject-introspection
     - pkg-config


### PR DESCRIPTION
Fix a typo in the cross-build script. See also conda-forge/librsvg-feedstock#77, conda-forge/pango-feedstock#45.

I also threw in a change to relax the Meson version pin since I think we might be able to remove it now, but I'll remove that from the history if that turns out to be wrong.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
