### PR TITLE
Rebuild with harfbuzz 3.1 to get an icu 68 compatible build

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -21,7 +21,7 @@ gdk_pixbuf:
 glib:
 - '2'
 harfbuzz:
-- '3'
+- '3.1'
 pango:
 - '1.48'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -25,7 +25,7 @@ gdk_pixbuf:
 glib:
 - '2'
 harfbuzz:
-- '3'
+- '3.1'
 pango:
 - '1.48'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -21,7 +21,7 @@ gdk_pixbuf:
 glib:
 - '2'
 harfbuzz:
-- '3'
+- '3.1'
 pango:
 - '1.48'
 pin_run_as_build:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -17,7 +17,7 @@ gdk_pixbuf:
 glib:
 - '2'
 harfbuzz:
-- '3'
+- '3.1'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pango:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -17,7 +17,7 @@ gdk_pixbuf:
 glib:
 - '2'
 harfbuzz:
-- '3'
+- '3.1'
 macos_machine:
 - arm64-apple-darwin20.0.0
 pango:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -13,7 +13,7 @@ gdk_pixbuf:
 glib:
 - '2'
 harfbuzz:
-- '3'
+- '3.1'
 libiconv:
 - '1.16'
 pango:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     - 0001-macOS-Fix-QuartzCore-linking-and-compiling-with-10.1.patch
 
 build:
-  number: 0
+  number: 1
   # workaround for bug in LIEF (https://github.com/lief-project/LIEF/issues/239)
   # that resulted in missing symbols
   rpaths_patcher: patchelf  # [linux]


### PR DESCRIPTION
Qt is still stuck on icu 68, and harfbuzz 3.2 has migrated to icu 69 only, so temporarily moving the pin back to harfbuzz 3.1 will allow this latest gtk3 build to be installed with qt. The pin will be reverted on the next rerender, so this is basically a one-off.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
