### PR TITLE
Restrict bot version updates to major version 3

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,5 +1,10 @@
 azure:
   store_build_artifacts: true
+bot:
+  version_updates:
+    even_odd_versions: true
+    exclude:
+      - '4.3.0'
 conda_build:
   pkg_format: '2'
 conda_forge_output_validation: true

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,14 +3,14 @@
 
 {% set name = "gtk" %}
 {% set version = "3.24.51" %}
-{% set version_majmin = '.'.join(version.split('.', 2)[:2]) %}
+{% set version_minor = version.split('.', 2)[1] %}
 
 package:
   name: gtk3-split
   version: {{ version }}
 
 source:
-  url: https://download.gnome.org/sources/{{ name }}/{{ version_majmin }}/{{ name }}-{{ version }}.tar.xz
+  url: https://download.gnome.org/sources/{{ name }}/3.{{ version_minor }}/{{ name }}-{{ version }}.tar.xz
   sha256: 0013877c6bd23c2dbe42ad7c70a053d0e449be66736574e37867c49c5f905a4f
   patches:
     - 0001-Use-G_PI-instead-of-M_PI.patch


### PR DESCRIPTION
Do this by hard-coding the major version 3 in the source url, instead of pulling it from the version number. This way, the bot will only get valid source URLs for minor or patch version updates and so will only see those.

This way we won't get the bot offering to update the feedstock to gtk4.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* ~[ ] Bumped the build number (if the version is unchanged)~
* ~[ ] Reset the build number to `0` (if the version changed)~
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
